### PR TITLE
Handle a "." if it refers to a lambda

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -260,7 +260,7 @@ Data * Renderer::_lookup(Node * node)
 {
   Data * data = _stack->back();
   
-  if( data->type == Data::TypeString ) {
+  if( data->type == Data::TypeString || data->type == Data::TypeLambda ) {
     // Simple
     if( node->data->compare(".") == 0 ) {
       return data;


### PR DESCRIPTION
I found an issue with handling lists of lambdas. Corresponding test for php-mustache is on the [lambdas_in_lists](https://github.com/wayfair/php-mustache/tree/lambdas_in_lists) branch. I'll post that PR after this and the other related libmustache PR are approved.