### PR TITLE
Free memory used by array data

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -43,7 +43,13 @@ Data::~Data()
         children.clear();
       }
     case Data::TypeArray:
-      //delete[] array;
+      if( array.size() > 0 ) {
+        Data::Array::iterator arrayIt;
+        for ( arrayIt = array.begin() ; arrayIt != array.end(); arrayIt++ ) {
+          delete *arrayIt;
+        }
+        array.clear();
+      }
       break;
     case Data::TypeLambda:
       delete lambda;


### PR DESCRIPTION
I found an issue with handling lists of lambdas. Then, when writing the corresponding test for php-mustache, which is on the [lambdas_in_lists](https://github.com/wayfair/php-mustache/tree/lambdas_in_lists) branch, I found that some memory was not being freed. I'll post the php-mustache PR after this and the other related libmustache PR are approved.