### PR TITLE
Update submodule URL for spec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec"]
 	path = spec
-	url = git://github.com/jbboehr/mustache-spec.git
+	url = https://github.com/jbboehr/mustache-spec.git


### PR DESCRIPTION
GitHub has discontinued support for the unencrypted `git://` protocol,[1] so fresh clones are unable to initialize the submodule. Fix it by switching the URL to HTTPS.

---
[1] https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/