### PR TITLE
Support some new features from the updated spec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec"]
 	path = spec
-	url = https://github.com/jbboehr/mustache-spec.git
+	url = https://github.com/mustache/spec.git

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -86,7 +86,7 @@ int Data::isEmpty()
       ret = 1;
       break;
     case Data::TypeString:
-      if( val == NULL || val->length() <= 0 ) {
+      if( val == NULL || val->length() <= 0 || *val == "null" ) {
         ret = 1;
       }
       break;

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -184,9 +184,11 @@ void Renderer::_renderNode(Node * node)
         switch( val->type ) {
           default:
           case Data::TypeString:
+            _stack->push_back(val);
             for( Node::Children::iterator it = node->children.begin() ; it != node->children.end(); it++ ) {
               _renderNode(*it);
             }
+            _stack->pop_back();
             break;
           case Data::TypeList:
             for( Data::List::iterator childrenIt = val->children.begin() ; childrenIt != val->children.end(); childrenIt++ ) {

--- a/tests/test_spec.cpp
+++ b/tests/test_spec.cpp
@@ -158,6 +158,11 @@ void mustache_spec_parse_test(yaml_document_t * document, yaml_node_t * node)
   if( node->type != YAML_MAPPING_NODE ) {
     return;
   }
+
+  // Support for inheritance and dynamic names is not implemented yet.
+  if (strcmp(currentSuite, "~inheritance.yml") == 0 || strcmp(currentSuite, "~dynamic-names.yml") == 0) {
+    return;
+  }
   
   MustacheSpecTest * test = new MustacheSpecTest;
   
@@ -177,6 +182,8 @@ void mustache_spec_parse_test(yaml_document_t * document, yaml_node_t * node)
         test->tmpl.assign(valueValue);
       } else if( strcmp(keyValue, "expected") == 0 ) {
         test->expected.assign(valueValue);
+      } else if (strcmp(keyValue, "data") == 0) {
+        mustache_spec_parse_data(document, valueNode, &test->data);
       }
     } else if( valueNode->type == YAML_MAPPING_NODE ) {
       if( strcmp(keyValue, "data") == 0 ) {


### PR DESCRIPTION
Handle accessing section data at the top of the context via {{.}} and add special-case handling for `null` sections. With these changes, all test cases from the spec pass, except for optional new features that are not yet implemented.

The specs submodule was updated in this PR only to verify this in CI as well. It can be restored to point back to the fork prior to merge.